### PR TITLE
OPA v1 compatibility enhancements. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,23 @@
+OPA_V0_COMPATIBLE ?= false
 SOURCE_FILES := $(shell find . -type f -name '*.rego')
 
 policy.wasm: $(SOURCE_FILES)
+ifeq ($(OPA_V0_COMPATIBLE), true)
+	opa build --v0-compatible -t wasm -e policy/main utility/policy.rego -o bundle.tar.gz policy.rego
+else
 	opa build -t wasm -e policy/main utility/policy.rego -o bundle.tar.gz policy.rego
+endif
 	tar xvf bundle.tar.gz /policy.wasm
 	rm bundle.tar.gz
 	touch policy.wasm # opa creates the bundle with unix epoch timestamp, fix it
 
 .PHONY: test
 test:
+ifeq ($(OPA_V0_COMPATIBLE), true)
+	opa test --v0-compatible *.rego
+else
 	opa test *.rego
+endif
 
 annotated-policy.wasm: policy.wasm metadata.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/README.md
+++ b/README.md
@@ -31,6 +31,31 @@ a `deny` object that is later embedded into an `AdmissionReview` response.
 The `AdmissionReview` object is defined inside of the `utility/policy.rego` file.
 You probably won't need to change this file.
 
+## Rego Policy code and OPA v1.0.0 compatibility
+
+With the release of OPA (Open Policy Agent)
+[v1.0.0](https://github.com/open-policy-agent/opa/releases/tag/v1.0.0) in
+December 2024, a breaking change was introduced regarding Rego policy syntax.
+
+Previously, `if` for all rule definitions and `contains` for multi-value rules
+were optional; now, they're mandatory. This change affects most older policies.
+
+Here's a summary of what you need to know:
+
+- OPA v1.0.0 Syntax: OPA v1.0.0 mandates the use of `if` for all rule
+  definitions and `contains` for multi-value rules. Policies not adhering to this
+  syntax will break.
+- Backward Compatibility: If you need to build older policies that don't use
+  the new v1.0.0 syntax, you must provide the `--v0-compatible` flag to the `opa
+build` command.
+
+What this means for you:
+
+- If your Rego policy follow the `v0` syntax. You must build the policy using
+  the `OPA_V0_COMPATIBLE=true make` command.
+- If your Rego policy follow `v1` syntax, you must build the
+  policy without any environment variable set.
+
 ## Testing
 
 The policy has some unit tests written using Rego, they can be found inside of

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ Rego policy targeting the Open Policy Agent framework into a Kubewarden policy.
 Don't forget to checkout Kubewarden's [official documentation](https://docs.kubewarden.io)
 for more information about writing policies.
 
+## Requirements
+
+To fully use this template, you'll need the following tools:
+
+- [opa](https://github.com/open-policy-agent/opa/releases): tool
+  to build the code into wasm. The version expected is `v1.0.0` or later
+- [kwctl](https://github.com/kubewarden/kwctl/releases): tool you use to
+  prepare and run Kubewarden web assembly module
+- [bats](https://github.com/bats-core/bats-core): tool used to run end-to-end
+  tests. If you decided to write such kind of tests
+
 ## Introduction
 
 **Note well:** the existing Rego code should not need to be rewritten.
@@ -15,8 +26,8 @@ for more information about writing policies.
 These are the only requirements you have to fulfill:
 
 1. The policy evaluation must return a `AdmissionReview` response object. This
-  is already a requirement for all the Open Policy Agent policies that are meant
-  to be used with Kubernetes.
+   is already a requirement for all the Open Policy Agent policies that are meant
+   to be used with Kubernetes.
 1. The policy must be compiled into a WebAssembly module using the `opa` cli tool.
 1. The policy must be annotated via `kwctl annotate`.
 
@@ -88,14 +99,14 @@ workflows.
 
 They take care of the following automations:
 
-  * Execute the Rego test suite
-  * Build the Rego files into a single WebAssembly module
-  * Annotate the WebAssembly module with Kubewarden's metadata
-  * Execute end-to-end tests
-  * Push events on the `main` branch lead the:
-    * Push the annotated WebAssembly module to the GitHub Container Registry using the
-      `:latest` tag.
-  * The creation of git tags lead to:
-    * Creation of the GitHub Release, holding the annotated WebAssembly module
-    * Push the annotated WebAssembly module to the GitHub Container Registry using the
-      `:<git tag>` tag.
+- Execute the Rego test suite
+- Build the Rego files into a single WebAssembly module
+- Annotate the WebAssembly module with Kubewarden's metadata
+- Execute end-to-end tests
+- Push events on the `main` branch lead the:
+  - Push the annotated WebAssembly module to the GitHub Container Registry using the
+    `:latest` tag.
+- The creation of git tags lead to:
+  - Creation of the GitHub Release, holding the annotated WebAssembly module
+  - Push the annotated WebAssembly module to the GitHub Container Registry using the
+    `:<git tag>` tag.


### PR DESCRIPTION
## Description

Updates the Makefile to allow users to build policies written in rego code v0 syntax. To build such policies, users now need to call make targets using the `OPA_V0_COMPATIBLE=true` variable. Update the documentation to cover this changes as well. 
    
Spin off https://github.com/kubewarden/gatekeeper-policy-template/pull/47
